### PR TITLE
#41 add: Top画面のPriorityのSelect機能追加

### DIFF
--- a/components/PrioritySelect.tsx
+++ b/components/PrioritySelect.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
+import { Select } from "@chakra-ui/react";
+
+import { todoListState } from "../constants/atom";
+
+type Props = {
+  arrIndex: number;
+  defaultValue: string;
+};
+
+// arrIndexにはtodoListをmapした時のindex、defaultValueには該当のpriorityを渡してください
+const PrioritySelect = ({ arrIndex, defaultValue }: Props) => {
+  const [selectValue, setSelectValue] = useState(defaultValue);
+  const [todoList, setTodoList] = useRecoilState<any>(todoListState);
+
+  useEffect(() => {
+    const todos = todoList.map((todo: any, index: number) =>
+      arrIndex === index
+        ? {
+            id: todo.id,
+            title: todo.title,
+            detail: todo.detail,
+            status: todo.status,
+            priority: selectValue,
+            createAt: todo.createAt,
+            category: todo.category,
+          }
+        : todo
+    );
+    setTodoList(todos);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectValue]);
+
+  return (
+    <Select
+      h={`40px`}
+      w={`112px`}
+      mx={`auto`}
+      borderColor={`red.500`}
+      borderRadius={`10px`}
+      defaultValue={defaultValue}
+      onChange={(e) => {
+        setSelectValue(e.target.value);
+      }}
+    >
+      <option value="high">High</option>
+      <option value="middle">Middle</option>
+      <option value="low">Low</option>
+    </Select>
+  );
+};
+
+export default PrioritySelect;


### PR DESCRIPTION
## issueのURL
- #41

## 変更内容・変更理由
Top画面のPriorityのSelect機能追加

## やったこと
- Top画面よりpropsとして渡されたPriorityを初期値として表示
- High、Middle、Lowの３種類の値が選択できる様にした
- 初期値から他の値に変えたとして、それが反映され、atomのtodoListに保存される

## やってないこと・できていないこと
特に無し

## UI before / after
UIは変更なし

## テスト（ブラウザかコードでの動作確認）
- Selectを選択すると、High、Middle、Lowの３種類の値が選択可能
- 初期値から他の値に変えたとして、それが反映され保存
[![Image from Gyazo](https://i.gyazo.com/a8c9bd21572e743902af5ecb5e054d3f.png)](https://gyazo.com/a8c9bd21572e743902af5ecb5e054d3f)

## レビュー観点
あくまで目安です。

- [ ] 想定通りに動作するか？
- [ ] より良いJS/JSX/TS/TSX/CSS/Reactの書き方はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数、コンポーネントの粒度は適切か？（大き過ぎる、細かすぎる）
- [ ] より良い設計方法はないか？
- [ ] etc...

## 補足
特に無し
