### PR TITLE
#55 404ページにTopページに遷移する機能を追加

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,9 @@ import { useRouter } from "next/router";
 
 export const Header = () => {
   const router = useRouter();
+  const date = new Date();
+  const formatDate =
+    date.getFullYear() + "/" + (date.getMonth() + 1) + "/" + date.getDate();
   return (
     <Flex h="80px" bgColor="green.300" alignItems="center">
       <Heading
@@ -20,7 +23,7 @@ export const Header = () => {
       </Heading>
       <Spacer />
       <Text color="blackAlpha.800" mr="100px" fontSize="16px" fontWeight="bold">
-        2022/01/01
+        {formatDate}
       </Text>
     </Flex>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { Flex, Heading, Spacer, Text } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 
 export const Header = () => {
+  const router = useRouter();
   return (
     <Flex h="80px" bgColor="green.300" alignItems="center">
       <Heading
@@ -9,6 +11,10 @@ export const Header = () => {
         ml="99px"
         fontSize="48px"
         fontWeight="bold"
+        _hover={{
+          cursor: "pointer",
+        }}
+        onClick={() => router.push("/Top")}
       >
         TODO
       </Heading>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import { Button, Container, Text, VStack } from "@chakra-ui/react";
 
 import { Header } from "../components/Header";
 
 export default function Custom404() {
+  const router = useRouter();
   return (
     <>
       <Head>
@@ -40,6 +42,7 @@ export default function Custom404() {
             borderWidth="1px"
             borderColor="blackAlpha.800"
             borderRadius="50px"
+            onClick={() => router.push("/Top")}
           >
             TOP
           </Button>


### PR DESCRIPTION
## issueのURL
- #55

## 変更内容・変更理由
ヘッダーと404ページに機能を追加

## やったこと
- ヘッダーのTODOをクリックすると、Topページに遷移
- ヘッダーの右側にアクセスした時の年月日を表示
-  404ページの`TOP`を押すと、Topページに遷移

## やってないこと・できていないこと
特に無し

## UI before / after
- before
[![Image from Gyazo](https://i.gyazo.com/760c0fc2590becdbbe6c21792fb14027.png)](https://gyazo.com/760c0fc2590becdbbe6c21792fb14027)
- after
[![Image from Gyazo](https://i.gyazo.com/73669b22349c391e4b70f95758a7894e.gif)](https://gyazo.com/73669b22349c391e4b70f95758a7894e)

## テスト（ブラウザかコードでの動作確認）
- [x] ヘッダーのTODOをクリックすると、Topページに遷移
- [x] 404ページの`TOP`を押すと、Topページに遷移

## レビュー観点
あくまで目安です。

- [ ] 想定通りに動作するか？
- [ ] より良いJS/JSX/TS/TSX/CSS/Reactの書き方はないか？
- [ ] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [ ] 関数、コンポーネントの粒度は適切か？（大き過ぎる、細かすぎる）
- [ ] より良い設計方法はないか？
- [ ] etc...

## 補足
特に無し
